### PR TITLE
feat: add Claude Code as an alternative analysis backend

### DIFF
--- a/CHEATSHEET.md
+++ b/CHEATSHEET.md
@@ -1,0 +1,178 @@
+# Supply Chain Monitor — Command Cheatsheet
+
+## package_diff.py — Generate a diff report
+
+Compare two published versions of a package and produce a markdown diff report.
+
+```bash
+# PyPI (default)
+python package_diff.py requests 2.31.0 2.32.0
+
+# npm
+python package_diff.py express 4.18.0 4.18.2 --npm
+
+# Save report to file instead of stdout
+python package_diff.py requests 2.31.0 2.32.0 -o diff.md
+
+# Compare local archives (no download)
+python package_diff.py --local old.tar.gz new.tar.gz
+python package_diff.py --local old.whl new.whl -n mypackage
+
+# Keep downloaded/extracted files for inspection
+python package_diff.py requests 2.31.0 2.32.0 --keep
+```
+
+---
+
+## analyze_diff.py — Analyze a diff for supply chain compromise
+
+Takes the markdown file produced by `package_diff.py` and returns `malicious` or `benign`.
+
+### Backends
+
+| Flag | Backend | Default model |
+|------|---------|---------------|
+| *(omit)* | Cursor Agent | `composer-2-fast` |
+| `--backend claude` | Claude Code CLI | `claude-sonnet-4-6` |
+
+```bash
+# Cursor Agent (default)
+python analyze_diff.py diff.md
+
+# Claude Code
+python analyze_diff.py diff.md --backend claude
+
+# Override model
+python analyze_diff.py diff.md --backend claude --model claude-opus-4-6
+python analyze_diff.py diff.md --model composer-2-fast   # cursor with specific model
+
+# Output as JSON (useful for scripting/CI)
+python analyze_diff.py diff.md --backend claude --json
+python analyze_diff.py diff.md --json
+```
+
+### Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Benign |
+| `1` | Malicious |
+| `2` | Unknown / backend error |
+
+---
+
+## Full pipeline — diff then analyze in one line
+
+```bash
+# PyPI + Claude Code
+python package_diff.py requests 2.31.0 2.32.0 -o diff.md && \
+  python analyze_diff.py diff.md --backend claude
+
+# PyPI + Claude Opus (more thorough)
+python package_diff.py cryptography 41.0.0 41.0.1 -o diff.md && \
+  python analyze_diff.py diff.md --backend claude --model claude-opus-4-6
+
+# npm + Claude Code
+python package_diff.py express 4.18.0 4.18.2 --npm -o diff.md && \
+  python analyze_diff.py diff.md --backend claude
+
+# PyPI + Cursor Agent
+python package_diff.py requests 2.31.0 2.32.0 -o diff.md && \
+  python analyze_diff.py diff.md
+
+# JSON verdict for CI/scripting
+python package_diff.py requests 2.31.0 2.32.0 -o diff.md && \
+  python analyze_diff.py diff.md --backend claude --json
+```
+
+---
+
+## monitor.py — Continuous supply chain monitor
+
+Polls PyPI and npm for new releases of the top N packages, diffs each new release,
+analyzes it with Cursor Agent or Claude Code, and alerts Slack on malicious findings.
+
+### Backends
+
+| Flag | Backend | Default model |
+|------|---------|---------------|
+| *(omit)* | Cursor Agent | `composer-2-fast` |
+| `--backend claude` | Claude Code CLI | `claude-sonnet-4-6` |
+
+```bash
+# Monitor both PyPI and npm (default: top 15000, poll every 300s, Cursor backend)
+python monitor.py
+
+# Use Claude Code as the analysis backend
+python monitor.py --backend claude
+
+# Override model
+python monitor.py --backend claude --model claude-opus-4-6
+python monitor.py --model composer-2-fast   # cursor with specific model
+
+# Monitor top N packages per ecosystem
+python monitor.py --top 5000
+
+# Change poll interval (seconds)
+python monitor.py --interval 120
+
+# One-shot scan — check recent events once, then exit
+python monitor.py --once
+python monitor.py --once --backend claude
+
+# Enable Slack alerts for malicious findings
+python monitor.py --slack
+python monitor.py --slack --backend claude
+
+# PyPI only
+python monitor.py --no-npm
+
+# npm only
+python monitor.py --no-pypi
+
+# npm only, custom top count
+python monitor.py --no-pypi --npm-top 5000
+
+# Start PyPI polling from a specific serial
+python monitor.py --serial 12345678
+
+# Start npm polling from a specific sequence number
+python monitor.py --npm-seq 987654
+
+# Debug logging (shows raw AI output)
+python monitor.py --debug --backend claude
+```
+
+---
+
+## pypi_monitor.py — Lightweight PyPI-only watcher
+
+Polls PyPI changelog directly — prints new releases only, no diff or AI analysis.
+
+```bash
+# Monitor top 1000 packages, poll every 120s (default)
+python pypi_monitor.py
+
+# Monitor top 5000
+python pypi_monitor.py --top 5000
+
+# Custom poll interval
+python pypi_monitor.py --interval 60
+
+# Single check (last ~10 min of activity), then exit
+python pypi_monitor.py --once
+```
+
+---
+
+## Slack setup
+
+Create `etc/slack.json`:
+
+```json
+{
+  "url": "https://hooks.slack.com/services/YOUR/WEBHOOK/URL",
+  "bot_token": "xoxb-your-bot-token",
+  "channel": "C0123456789"
+}
+```

--- a/analyze_diff.py
+++ b/analyze_diff.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE file in the project root for details.
 
 """
-Analyze a package diff report for supply chain compromise using Cursor Agent CLI.
+Analyze a package diff report for supply chain compromise using Cursor Agent CLI or Claude Code CLI.
 
 Takes a diff markdown file (output of package_diff.py) and returns a verdict
 of "malicious" or "benign" with supporting analysis.
@@ -10,7 +10,8 @@ of "malicious" or "benign" with supporting analysis.
 Usage:
     python analyze_diff.py <diff_file>
     python analyze_diff.py telnyx_diff.md
-    python analyze_diff.py telnyx_diff.md --model claude-4-opus
+    python analyze_diff.py telnyx_diff.md --model claude-sonnet-4-6
+    python analyze_diff.py telnyx_diff.md --backend claude
     python analyze_diff.py telnyx_diff.md --json
 
 Can also be chained with package_diff.py:
@@ -60,6 +61,41 @@ Then explain your reasoning briefly.
 - Minified or bundled payloads added outside normal build artifacts
 
 Only report "malicious" if you are highly confident malicious code has been added.
+"""
+
+CLAUDE_INSTRUCTIONS_TEMPLATE = """\
+# Supply Chain Diff Review
+
+Review the diff below and determine if the changes are highly likely
+to show evidence of a supply chain compromise.
+
+## Response format
+
+Start your response with exactly one of these lines:
+
+    Verdict: malicious
+    Verdict: benign
+
+Then explain your reasoning briefly.
+
+## What to look for
+
+- Obfuscated code (base64, exec, eval, XOR, encoded strings)
+- Network calls to unexpected hosts (non-package-related URLs)
+- File system writes to startup/persistence locations
+- Process spawning, shell commands
+- Steganography or data hiding in media files
+- Credential/token exfiltration
+- Typosquatting indicators
+- Suspicious npm lifecycle scripts (preinstall, install, postinstall) in package.json
+- Dynamic require() or import() of obfuscated or encoded URLs
+- Minified or bundled payloads added outside normal build artifacts
+
+Only report "malicious" if you are highly confident malicious code has been added.
+
+## Diff to review
+
+{diff_content}
 """
 
 
@@ -117,30 +153,77 @@ def run_cursor_agent(diff_file: Path, model: str = "composer-2-fast") -> str:
     return result.stdout or ""
 
 
+def _find_claude() -> str:
+    claude = shutil.which("claude")
+    if claude:
+        return claude
+    raise FileNotFoundError(
+        "Claude Code CLI not found. Install with: "
+        "npm install -g @anthropic-ai/claude-code"
+    )
+
+
+def run_claude_code(diff_file: Path, model: str = "claude-sonnet-4-6") -> str:
+    claude_bin = _find_claude()
+    diff_content = diff_file.read_text(encoding="utf-8", errors="replace")
+    prompt = CLAUDE_INSTRUCTIONS_TEMPLATE.format(diff_content=diff_content)
+
+    cmd_parts = [claude_bin, "--print"]
+    if model:
+        cmd_parts.extend(["--model", model])
+
+    # Pass prompt via stdin to avoid OS "argument list too long" on large diffs
+    result = subprocess.run(
+        cmd_parts,
+        input=prompt,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=300,
+    )
+
+    log.debug("Claude stdout:\n%s", result.stdout or "(empty)")
+    log.debug("Claude stderr:\n%s", result.stderr or "(empty)")
+
+    if result.returncode != 0:
+        log.error("Claude Code exited %d: %s", result.returncode, result.stderr)
+        return ""
+
+    return result.stdout or ""
+
+
 def parse_verdict(output: str) -> tuple[str, str]:
-    """Extract verdict and reasoning from cursor output."""
-    verdict = "unknown"
-    match = re.search(r"[Vv]erdict:\s*(malicious|benign)", output, re.IGNORECASE)
-    if match:
-        verdict = match.group(1).lower()
+    """Extract verdict and reasoning from agent output."""
+    matches = re.findall(r"[Vv]erdict:\s*(malicious|benign)", output, re.IGNORECASE)
+    verdict = matches[-1].lower() if matches else "unknown"
     return verdict, output.strip()
 
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Analyze a package diff for supply chain compromise via Cursor Agent",
+        description="Analyze a package diff for supply chain compromise via Cursor Agent or Claude Code",
     )
     parser.add_argument("diff_file", type=Path, help="Path to diff markdown file (from package_diff.py)")
-    parser.add_argument("--model", help="Model to use (default: composer-2-fast)")
+    parser.add_argument("--model", help="Model to use (default: composer-2-fast for cursor, claude-sonnet-4-6 for claude)")
+    parser.add_argument("--backend", choices=["cursor", "claude"], default="cursor", help="AI backend to use (default: cursor)")
     parser.add_argument("--json", action="store_true", dest="json_output", help="Output as JSON")
     args = parser.parse_args()
 
     if not args.diff_file.exists():
         parser.error(f"File not found: {args.diff_file}")
 
-    print(f"[*] Analyzing {args.diff_file.name} with Cursor Agent...", file=sys.stderr)
+    if args.backend == "claude":
+        print(f"[*] Analyzing {args.diff_file.name} with Claude Code...", file=sys.stderr)
+        raw_output = run_claude_code(args.diff_file, model=args.model or "claude-sonnet-4-6")
+    else:
+        print(f"[*] Analyzing {args.diff_file.name} with Cursor Agent...", file=sys.stderr)
+        raw_output = run_cursor_agent(args.diff_file, model=args.model or "composer-2-fast")
 
-    raw_output = run_cursor_agent(args.diff_file, model=args.model)
+    if not raw_output:
+        print("[!] Backend returned no output — check logs for errors.", file=sys.stderr)
+        sys.exit(2)
+
     verdict, analysis = parse_verdict(raw_output)
 
     if args.json_output:

--- a/monitor.py
+++ b/monitor.py
@@ -38,7 +38,7 @@ import xmlrpc.client
 from datetime import datetime, timezone
 from pathlib import Path
 
-from analyze_diff import parse_verdict, run_cursor_agent
+from analyze_diff import parse_verdict, run_claude_code, run_cursor_agent
 from package_diff import (
     collect_files,
     download_npm_package,
@@ -247,15 +247,19 @@ def analyze_report(
     new_version: str,
     *,
     model: str | None = None,
+    backend: str = "cursor",
 ) -> tuple[str, str]:
-    """Write report to a temp workspace, run Cursor Agent, return (verdict, analysis)."""
+    """Write report to a temp workspace, run AI analysis, return (verdict, analysis)."""
     safe_name = package.replace("/", "_").replace("@", "")
     workspace = Path(tempfile.mkdtemp(prefix=f"scm_analyze_{safe_name}_"))
     diff_file = workspace / f"{safe_name}_diff.md"
     diff_file.write_text(report, encoding="utf-8")
-    log.info("Diff written to %s", diff_file)
+    log.info("Diff written to %s (backend: %s)", diff_file, backend)
     try:
-        raw_output = run_cursor_agent(diff_file, model=model or "composer-2-fast")
+        if backend == "claude":
+            raw_output = run_claude_code(diff_file, model=model or "claude-sonnet-4-6")
+        else:
+            raw_output = run_cursor_agent(diff_file, model=model or "composer-2-fast")
         verdict, analysis = parse_verdict(raw_output)
     except Exception:
         log.error("Analysis failed for %s %s:\n%s", package, new_version, traceback.format_exc())
@@ -516,6 +520,7 @@ def process_npm_release(
     slack: bool = False,
     *,
     model: str | None = None,
+    backend: str = "cursor",
 ) -> str:
     """Full pipeline for one npm release: diff -> analyze -> alert. Returns verdict."""
     log.info("[npm] Processing %s %s (rank #%s)...", package, new_version, f"{rank:,}")
@@ -532,7 +537,7 @@ def process_npm_release(
 
     try:
         log.info("[npm] Analyzing diff for %s...", package)
-        verdict, analysis = analyze_report(report, package, new_version, model=model)
+        verdict, analysis = analyze_report(report, package, new_version, model=model, backend=backend)
         log.info("[npm] Verdict for %s %s: %s", package, new_version, verdict.upper())
 
         if verdict == "malicious":
@@ -574,6 +579,7 @@ def process_release(
     slack: bool = False,
     *,
     model: str | None = None,
+    backend: str = "cursor",
 ) -> str:
     """Full pipeline for one release: diff -> analyze -> alert. Returns verdict."""
     log.info("[pypi] Processing %s %s (rank #%s)...", package, new_version, f"{rank:,}")
@@ -590,7 +596,7 @@ def process_release(
 
     try:
         log.info("[pypi] Analyzing diff for %s...", package)
-        verdict, analysis = analyze_report(report, package, new_version, model=model)
+        verdict, analysis = analyze_report(report, package, new_version, model=model, backend=backend)
         log.info("[pypi] Verdict for %s %s: %s", package, new_version, verdict.upper())
 
         if verdict == "malicious":
@@ -610,6 +616,7 @@ def poll_loop(
     initial_serial: int | None = None,
     state_path: Path | None = None,
     model: str | None = None,
+    backend: str = "cursor",
 ):
     state_path = state_path or LAST_SERIAL_PATH
     client = xmlrpc.client.ServerProxy(PYPI_XMLRPC)
@@ -663,7 +670,7 @@ def poll_loop(
             for package, version, ts in releases:
                 rank = watchlist.get(package.lower(), 0)
                 verdict = process_release(
-                    package, version, rank, slack=slack, model=model,
+                    package, version, rank, slack=slack, model=model, backend=backend,
                 )
                 stats["checked"] += 1
                 stats[verdict] = stats.get(verdict, 0) + 1
@@ -684,6 +691,7 @@ def run_once(
     *,
     since_serial: int | None = None,
     model: str | None = None,
+    backend: str = "cursor",
 ):
     client = xmlrpc.client.ServerProxy(PYPI_XMLRPC)
     current_serial = client.changelog_last_serial()
@@ -708,7 +716,7 @@ def run_once(
 
     for package, version, ts in releases:
         rank = watchlist.get(package.lower(), 0)
-        process_release(package, version, rank, slack=slack, model=model)
+        process_release(package, version, rank, slack=slack, model=model, backend=backend)
 
 
 # ---------------------------------------------------------------------------
@@ -723,6 +731,7 @@ def npm_poll_loop(
     initial_seq: int | None = None,
     state_path: Path | None = None,
     model: str | None = None,
+    backend: str = "cursor",
 ):
     state_path = state_path or LAST_SERIAL_PATH
 
@@ -801,7 +810,7 @@ def npm_poll_loop(
             for pkg, version in releases:
                 rank = watchlist.get(pkg.lower(), 0)
                 verdict = process_npm_release(
-                    pkg, version, rank, slack=slack, model=model,
+                    pkg, version, rank, slack=slack, model=model, backend=backend,
                 )
                 stats["checked"] += 1
                 stats[verdict] = stats.get(verdict, 0) + 1
@@ -821,6 +830,7 @@ def npm_run_once(
     lookback_seconds: int = 600,
     *,
     model: str | None = None,
+    backend: str = "cursor",
 ):
     """One-shot: check for npm releases published in the last *lookback_seconds*."""
     cutoff_epoch = time.time() - lookback_seconds
@@ -858,7 +868,7 @@ def npm_run_once(
 
     for pkg, version in releases:
         rank = watchlist.get(pkg.lower(), 0)
-        process_npm_release(pkg, version, rank, slack=slack, model=model)
+        process_npm_release(pkg, version, rank, slack=slack, model=model, backend=backend)
 
 
 # ---------------------------------------------------------------------------
@@ -871,7 +881,8 @@ def main():
     parser.add_argument("--interval", type=int, default=300, help="Poll interval in seconds (default: 300)")
     parser.add_argument("--once", action="store_true", help="Single pass over recent events, then exit")
     parser.add_argument("--slack", action="store_true", help="Enable Slack alerts for malicious findings")
-    parser.add_argument("--model", help="Override model for Cursor Agent analysis")
+    parser.add_argument("--model", help="Override model for analysis (default depends on --backend)")
+    parser.add_argument("--backend", choices=["cursor", "claude"], default="cursor", help="AI backend for analysis (default: cursor)")
     parser.add_argument("--debug", action="store_true", help="Enable DEBUG logging (includes agent raw output)")
 
     pypi_group = parser.add_argument_group("PyPI options")
@@ -905,11 +916,12 @@ def main():
                 slack=args.slack,
                 since_serial=args.serial,
                 model=args.model,
+                backend=args.backend,
             )
         if enable_npm:
             npm_top = args.npm_top or args.top
             npm_watchlist = load_npm_watchlist(npm_top)
-            npm_run_once(npm_watchlist, slack=args.slack, model=args.model)
+            npm_run_once(npm_watchlist, slack=args.slack, model=args.model, backend=args.backend)
     else:
         threads: list[threading.Thread] = []
 
@@ -922,6 +934,7 @@ def main():
                     "slack": args.slack,
                     "initial_serial": args.serial,
                     "model": args.model,
+                    "backend": args.backend,
                 },
                 daemon=True,
                 name="pypi-poll",
@@ -938,6 +951,7 @@ def main():
                     "slack": args.slack,
                     "initial_seq": args.npm_seq,
                     "model": args.model,
+                    "backend": args.backend,
                 },
                 daemon=True,
                 name="npm-poll",


### PR DESCRIPTION
Adds --backend claude flag to analyze_diff.py and monitor.py, routing analysis through the Claude Code CLI instead of Cursor Agent. Also adds CHEATSHEET.md with usage examples for all scripts.

## Summary

<!-- Briefly describe what this PR does and why. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] Changes are focused (no unrelated refactors).
- [ ] I tested locally (e.g. `python monitor.py --once --no-npm` or relevant scripts).
- [ ] Documentation updated if behavior or setup changed.

## Related issues

<!-- Link issues with "Fixes #123" or "Relates to #123" if applicable. -->
